### PR TITLE
Fix ancestor-uses-init check

### DIFF
--- a/vendor/classic-decorator/index.js
+++ b/vendor/classic-decorator/index.js
@@ -39,7 +39,7 @@
   }
 
   function findAncestor(klass, predicate) {
-    if (BASE_CLASSES.has(klass) {
+    if (BASE_CLASSES.has(klass)) {
         return null;
     }
 

--- a/vendor/classic-decorator/index.js
+++ b/vendor/classic-decorator/index.js
@@ -39,6 +39,10 @@
   }
 
   function findAncestor(klass, predicate) {
+    if (BASE_CLASSES.has(klass) {
+        return null;
+    }
+
     while (klass !== null && Boolean(klass.prototype)) {
       if (predicate(klass)) {
         return klass;


### PR DESCRIPTION
The previous version of the implementation continues recursing up the prototype chain until it reaches the root of the tree, even when it has already hit one of the safe base classes. Add a check to return `null` if one of the safe base classes is found, since anything further up the tree is a private implementation detail.