### PR TITLE
[BUGFIX] Better Require Patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-template-lint": "^1.0.0-beta.1",
     "ember-cli-uglify": "^2.1.0",
-    "ember-decorators-polyfill": "^1.1.3",
+    "ember-decorators-polyfill": "^1.1.5",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^2.0.0",

--- a/vendor/classic-decorator/index.js
+++ b/vendor/classic-decorator/index.js
@@ -144,13 +144,13 @@
     return target;
   }
 
-  var mainRequire = require;
+  let originalRequire = window.require;
   window.require = require = function patchData(moduleName) {
     var DS, Resolver;
 
     try {
-      Resolver = mainRequire('ember-resolver').default;
-      DS = mainRequire('ember-data').default;
+      Resolver = originalRequire('ember-resolver').default;
+      DS = originalRequire('ember-data').default;
     } catch (e) {}
 
     if (Resolver) {
@@ -172,8 +172,8 @@
       IS_PERMA_CLASSIC.set(DS.Transform, false);
     }
 
-    window.require = require = mainRequire;
+    window.require = require = window.requirejs;
 
-    return mainRequire(moduleName);
+    return window.requirejs(moduleName);
   }
 })(window);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5321,10 +5321,10 @@ ember-data@~3.12.0:
     ember-cli-typescript "^2.0.2"
     ember-inflector "^3.0.1"
 
-ember-decorators-polyfill@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/ember-decorators-polyfill/-/ember-decorators-polyfill-1.1.3.tgz#2ffd7b5a4d45cb2a0dc7fce9cb132719a1134d13"
-  integrity sha512-38cVtAryDo0Dlv96wLQHJk273UUxU8UPKQenN4T0wlXqqifTldZ/brLK9Jp4gE99g2swHeG9EVvcTGPCwmCXmg==
+ember-decorators-polyfill@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/ember-decorators-polyfill/-/ember-decorators-polyfill-1.1.5.tgz#49203c302ea4486618ba4866923ec657cf2c9f3d"
+  integrity sha512-O154i8sLoVjsiKzSqxGRfHGr+N+drT6mRrLDbNgJCnW/V5uLg/ppZFpUsrdxuXnp5Q9us3OfXV1nX2CH+7bUpA==
   dependencies:
     ember-cli-babel "^7.1.2"
     ember-cli-version-checker "^3.1.3"


### PR DESCRIPTION
This version of the data patch doesn't rely on capturing the original
value. Instead it uses an alternate name that is defined by the AMD
loader internally, while replacing the main `require`.