### PR TITLE
Restore functions that were previously available at window.require.x

### DIFF
--- a/vendor/classic-decorator/index.js
+++ b/vendor/classic-decorator/index.js
@@ -149,6 +149,8 @@
   }
 
   let originalRequire = window.require;
+  let originalRequireEntries = Object.entries(window.require);
+
   window.require = require = function patchData(moduleName) {
     var DS, Resolver;
 
@@ -180,4 +182,8 @@
 
     return window.requirejs(moduleName);
   }
+
+  originalRequireEntries.forEach(
+    ([key, value]) => (window.require[key] = value)
+  );
 })(window);


### PR DESCRIPTION
I'm not sure about consequences or side effects of this, but this change seems to resolve the reported issue 🤷 

Names of `window.require.x` of functions copied over:
```js
["_eak_seen", "entries", "has", "unsee", "clear"]
```

Fixes #74