### PR TITLE
Fix ember-data class no longer recognized on Ember 3.27 or later

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "edition": "octane"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "after": "ember-cli-deprecation-workflow"
   },
   "release-it": {
     "plugins": {


### PR DESCRIPTION
Up to date PR related to this issue: https://github.com/emberjs/ember-classic-decorator/issues/80