### PR TITLE
Ember cli deprecation workflow compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "edition": "octane"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "after": "ember-cli-deprecation-workflow"
   },
   "release-it": {
     "plugins": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "ember-auto-import": "^2.4.0",
     "ember-cli": "~4.1.1",
     "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-deprecation-workflow": "^2.1.0",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-mirage": "^2.4.0",
     "ember-cli-sri": "^2.1.1",

--- a/tests/unit/classic-decorator-test.js
+++ b/tests/unit/classic-decorator-test.js
@@ -4,6 +4,10 @@ import EmberObject from '@ember/object';
 import Controller from '@ember/controller';
 import classic from 'ember-classic-decorator';
 import { DEBUG } from '@glimmer/env';
+import JSONAPIAdapter from '@ember-data/adapter/json-api';
+import RESTAdapter from '@ember-data/adapter/rest';
+import JSONAPISerializer from '@ember-data/serializer/json-api';
+import RESTSerializer from '@ember-data/serializer/rest';
 
 module('@classic', () => {
   if (DEBUG) {
@@ -32,6 +36,26 @@ module('@classic', () => {
         const Foo = EmberObject.extend({});
 
         Foo.create();
+      });
+    });
+
+    module('ED classes', () => {
+      test('Adapters', function (assert) {
+        assert.expect(0);
+        class Foo extends JSONAPIAdapter {}
+        Foo.create();
+
+        class Bar extends RESTAdapter {}
+        Bar.create();
+      });
+
+      test('Serializers', function (assert) {
+        assert.expect(0);
+        class Foo extends JSONAPISerializer {}
+        Foo.create();
+
+        class Bar extends RESTSerializer {}
+        Bar.create();
       });
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3241,7 +3241,7 @@ broccoli-persistent-filter@^3.1.2:
     symlink-or-copy "^1.0.1"
     sync-disk-cache "^2.0.0"
 
-broccoli-plugin@*, broccoli-plugin@^4.0.0, broccoli-plugin@^4.0.2, broccoli-plugin@^4.0.3, broccoli-plugin@^4.0.7:
+broccoli-plugin@*, broccoli-plugin@^4.0.0, broccoli-plugin@^4.0.2, broccoli-plugin@^4.0.3, broccoli-plugin@^4.0.5, broccoli-plugin@^4.0.7:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz#dd176a85efe915ed557d913744b181abe05047db"
   integrity sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==
@@ -4724,12 +4724,22 @@ ember-cli-dependency-checker@^3.2.0:
     resolve "^1.5.0"
     semver "^5.3.0"
 
+ember-cli-deprecation-workflow@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-deprecation-workflow/-/ember-cli-deprecation-workflow-2.1.0.tgz#f0d38ece7ac0ab7b3f83790a3a092e3472f58cff"
+  integrity sha512-Ay9P9iKMJdY4Gq5XPowh3HqqeAzLfwBRj1oB1ZKkDW1fryZQWBN4pZuRnjnB+3VWZjBnZif5e7Pacc7YNW9hWg==
+  dependencies:
+    broccoli-funnel "^3.0.3"
+    broccoli-merge-trees "^4.2.0"
+    broccoli-plugin "^4.0.5"
+    ember-cli-htmlbars "^5.3.2"
+
 ember-cli-get-component-path-option@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-get-component-path-option/-/ember-cli-get-component-path-option-1.0.0.tgz#0d7b595559e2f9050abed804f1d8eff1b08bc771"
   integrity sha1-DXtZVVni+QUKvtgE8djv8bCLx3E=
 
-ember-cli-htmlbars@^5.7.1:
+ember-cli-htmlbars@^5.3.2, ember-cli-htmlbars@^5.7.1:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz#e0cd2fb3c20d85fe4c3e228e6f0590ee1c645ba8"
   integrity sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==


### PR DESCRIPTION
If ember-classic-decorator is run before ember-cli-deprecation-workflow ember-cli-deprecation-workflow invokes `window.require` before the ember data classes exists. Therefore ember-classic-decorator's patch of window.require doesn't see ember data classes and it doesn't register them.

Run ember-classic-decorator after ember-cli-deprecation-workflow to resolve this problem.

Fixes #80 